### PR TITLE
[FIX] 시니어 로그인 화면 헤더 초기화 오류 버그 해결

### DIFF
--- a/lib/features/senior/presentation/views/login/senior_login_screen.dart
+++ b/lib/features/senior/presentation/views/login/senior_login_screen.dart
@@ -6,6 +6,8 @@ import 'package:weve_client/commons/widgets/senior/button/view/button.dart';
 import 'package:weve_client/commons/widgets/senior/login/view/input_field.dart';
 import 'package:weve_client/core/constants/colors.dart';
 import 'package:weve_client/features/senior/presentation/viewmodels/providers/senior_providers.dart';
+import 'package:weve_client/commons/widgets/header/model/header_type.dart';
+import 'package:weve_client/commons/widgets/header/viewmodel/header_viewmodel.dart';
 
 class SeniorLoginScreen extends ConsumerStatefulWidget {
   const SeniorLoginScreen({super.key});
@@ -17,6 +19,15 @@ class SeniorLoginScreen extends ConsumerStatefulWidget {
 class _SeniorLoginScreenState extends ConsumerState<SeniorLoginScreen> {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _phoneController = TextEditingController();
+  late final headerViewModel = ref.read(headerProvider.notifier);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      headerViewModel.resetHeader(type: HeaderType.backOnly);
+    });
+  }
 
   @override
   void dispose() {


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#64 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 헤더 타입을 'backOnly'로 설정하는 초기화 로직 추가
- 시니어 로그인 화면에서 헤더 타입을 leftLogo에서 backOnly로 변경하여 백버튼만 표시되도록 수정함.
- 헤더 뷰모델을 사용하여 로그인 화면의 상태 관리 개선

이를 통해 로그아웃 후 시니어 모드 진입 시 헤더가 일관되게 표시되도록
문제를 해결함.

- 예시 화면은 아래와 같음.
![화면 기록 2025-05-14 오후 9 13 49](https://github.com/user-attachments/assets/df627c35-619f-4398-b57a-fab5a91612f4)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
