### PR TITLE
[FIX] IndexScreen에 화면 전환 및 헤더 백버튼 네비게이션 로직 개선

### DIFF
--- a/lib/commons/presentation/index_screen.dart
+++ b/lib/commons/presentation/index_screen.dart
@@ -5,6 +5,10 @@ import 'package:weve_client/commons/presentation/main_screen.dart';
 import 'package:weve_client/commons/widgets/junior/header/view/header.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weve_client/core/constants/custom_animation_image.dart';
+import 'package:weve_client/commons/widgets/header/view/header_widget.dart';
+import 'package:weve_client/commons/widgets/header/model/header_type.dart';
+import 'package:weve_client/commons/widgets/header/viewmodel/header_viewmodel.dart';
+import 'package:weve_client/commons/presentation/language_screen.dart';
 
 class IndexScreen extends ConsumerStatefulWidget {
   static const String routeName = 'index';
@@ -16,48 +20,79 @@ class IndexScreen extends ConsumerStatefulWidget {
 }
 
 class _IndexScreenState extends ConsumerState<IndexScreen> {
+  late final headerViewModel = ref.read(headerProvider.notifier);
+  bool _isNavigating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // HeaderType.backOnly 설정
+      headerViewModel.resetHeader(type: HeaderType.backOnly);
+
+      // 콜백은 설정하지 않음 - HeaderWidget이 자체적으로 pop을 처리하도록 함
+    });
+  }
+
+  @override
+  void dispose() {
+    // dispose 시에는 콜백 초기화만 해주고 다른 작업 하지 않음
+    headerViewModel.clearBackPressedCallback();
+    super.dispose();
+  }
+
+  // WillPopScope에서 사용할 메서드 - 기본 시스템 백버튼 처리
+  Future<bool> _onWillPop() async {
+    // 시스템 백버튼에 의한 pop은 true 반환하여 기본 동작 허용
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            const Spacer(),
-            const JuniorHeader(),
-            const SizedBox(height: 80),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  ModeButton(
-                    modeTypeModel: ModeTypeModel(
-                      type: ModeType.junior,
+    return WillPopScope(
+      onWillPop: _onWillPop,
+      child: Scaffold(
+        appBar: HeaderWidget(),
+        body: SafeArea(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Spacer(),
+              const JuniorHeader(),
+              const SizedBox(height: 80),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    ModeButton(
+                      modeTypeModel: ModeTypeModel(
+                        type: ModeType.junior,
+                      ),
+                      targetScreen: const MainScreen(modeType: ModeType.junior),
                     ),
-                    targetScreen: const MainScreen(modeType: ModeType.junior),
-                  ),
-                  const SizedBox(width: 20),
-                  ModeButton(
-                    modeTypeModel: ModeTypeModel(
-                      type: ModeType.senior,
+                    const SizedBox(width: 20),
+                    ModeButton(
+                      modeTypeModel: ModeTypeModel(
+                        type: ModeType.senior,
+                      ),
+                      targetScreen: const MainScreen(modeType: ModeType.senior),
                     ),
-                    targetScreen: const MainScreen(modeType: ModeType.senior),
-                  ),
-                ],
-              ),
-            ),
-            const Spacer(),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 50.0),
-              child: SizedBox(
-                width: MediaQuery.of(context).size.width * 0.75,
-                child: CustomAnimationImages.getAnimation(
-                  CustomAnimationImages.weveCharacter,
+                  ],
                 ),
               ),
-            ),
-          ],
+              const Spacer(),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 50.0),
+                child: SizedBox(
+                  width: MediaQuery.of(context).size.width * 0.75,
+                  child: CustomAnimationImages.getAnimation(
+                    CustomAnimationImages.weveCharacter,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/commons/presentation/language_screen.dart
+++ b/lib/commons/presentation/language_screen.dart
@@ -67,7 +67,7 @@ class _LanguageScreenState extends ConsumerState<LanguageScreen> {
       floatingActionButton: selectedLanguage != null
           ? FloatingActionButton(
               onPressed: () {
-                Navigator.of(context).pushReplacement(
+                Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (context) => const IndexScreen(),
                   ),


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#60 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- language_screen에서 index_screen으로 이동 시 pushReplacement 대신 push 사용하여 네비게이션 스택 유지
- index_screen에서 백버튼 처리 로직 간소화 및 HeaderWidget의 기본 네비게이션 활용
- 시니어 로그인 화면의 헤더 타입을 HeaderType.backOnly로 변경하여 백버튼만 표시


![화면 기록 2025-05-14 오후 9 34 34](https://github.com/user-attachments/assets/54215784-3d5f-4f51-b06b-249e736d3462)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
